### PR TITLE
fixed pawn double moves

### DIFF
--- a/src/apps/chess/game/pieces/pawn-piece.ts
+++ b/src/apps/chess/game/pieces/pawn-piece.ts
@@ -142,15 +142,13 @@ export class Pawn extends Piece {
       // Move two squares forward
       if (nextSquare && !nextSquare.piece) {
         availableSquares.push(nextSquare);
-      }
-
-      const moveTwoSquaresForward = this.board.getSquare(
-        this.square.row + 2,
-        this.square.column,
-      );
-
-      if (moveTwoSquaresForward && !moveTwoSquaresForward.piece) {
-        availableSquares.push(moveTwoSquaresForward);
+        const moveTwoSquaresForward = this.board.getSquare(
+          this.square.row + 2,
+          this.square.column,
+        );
+        if (moveTwoSquaresForward && !moveTwoSquaresForward.piece) {
+          availableSquares.push(moveTwoSquaresForward);
+        }
       }
     }
 


### PR DESCRIPTION
problem : 
![2](https://github.com/user-attachments/assets/94f3f1ab-39f4-4da5-b1b7-bc87288863e4)


bug :
if black pawn is front of white pawn then white player can't be move one square forward or two square forward also.

fixing :
just i was move correct code in right place "moved code of double move square inside one move square check"

code :
i moved "moveTwoSquaresForward" inside 'nextSquare' block check